### PR TITLE
API can provide list of products

### DIFF
--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MenuItemsController < ApplicationController
-	def index
-		items = MenuItem.all
-		render json: { items: items }
-	end
+  def index
+    items = MenuItem.all
+    render json: { menu_items: items }
+  end
 end

--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::MenuItemsController < ApplicationController
+	def index
+		items = MenuItem.all
+		render json: { items: items }
+	end
+end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,0 +1,3 @@
+class MenuItem < ApplicationRecord
+	validates_presence_of :name, :price
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
     namespace :v0 do
       resources :pings, only: [:index], constraints: { format: 'json' }
     end
+    namespace :v1 do
+      resources :menu_items, only: [:index], constraints: { format: 'json' }
+    end
   end
 end

--- a/db/migrate/20200505094922_create_menu_items.rb
+++ b/db/migrate/20200505094922_create_menu_items.rb
@@ -1,0 +1,11 @@
+class CreateMenuItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :menu_items do |t|
+      t.string :name
+      t.text :description
+      t.float :price
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_05_05_094922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "menu_items", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.float "price"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+food1 = MenuItem.create(name: 'Pickled Egg', description: 'An egg that is a reeeeal pickle!', price: 69)
+food2 = MenuItem.create(name: 'Bread', description: 'Simply bread', price: 25)
+food3 = MenuItem.create(name: 'Ham Sandwich', description: 'No, not hamBURGER, ham SANDWICH', price: 42)

--- a/spec/factories/menu_items.rb
+++ b/spec/factories/menu_items.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :menu_item do
+    name { "MyString" }
+    description { "MyText" }
+    price { 69.0 }
+  end
+end

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe MenuItem, type: :model do
+  describe 'Database table' do
+    it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :price }
+  end
+
+  describe 'Validation' do
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :price }
+  end
+
+  describe 'Factory' do
+    it "should have a valid factory" do
+      expect(create(:menu_item)).to be_valid
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ ActiveRecord::Migration.maintain_test_schema!
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include ResponseJSON
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/requests/api/v1/menu_items_spec.rb
+++ b/spec/requests/api/v1/menu_items_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe API::V1::MenuItemsController, type: :request do
+RSpec.describe Api::V1::MenuItemsController, type: :request do
+    let!(:food1) { create(:menu_item, name: 'Pickled Egg', description: 'An egg that is in a reeeeal pickle!', price: 69) }
+    let!(:food2) { create(:menu_item, name: 'Bread', description: 'Simply bread', price: 25) }
+    let!(:food3) { create(:menu_item, name: 'Ham Sandwich', description: 'No, not hamBURGER, ham SANDWICH', price: 42) }
+
     describe 'GET /v1/menu_items' do
         before do
-            get 'api/v1/menu_items'
+            get '/api/v1/menu_items'
         end
 
         it 'should return a 200 response' do
@@ -11,16 +15,18 @@ RSpec.describe API::V1::MenuItemsController, type: :request do
         end
 
         describe 'should return a response with' do
-            before do
-                json_response = JSON.parse(response.body)
-            end
+            let(:json_response) { JSON.parse(response.body) }
 
             it 'should return a list of menu items' do
-                expect(json_response.length).to eq 3
+                expect(json_response["items"].length).to eq 3
             end
 
             it 'should return items with a name' do
-                expect(json_response[0][:name]).to eq 'Pickled egg'
+                expect(json_response["items"][0]["name"]).to eq food1.name
+            end
+
+            it 'should return items with a price' do
+                expect(json_response["items"][0]["price"]).to eq food1.price
             end
         end
     end

--- a/spec/requests/api/v1/menu_items_spec.rb
+++ b/spec/requests/api/v1/menu_items_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe API::V1::MenuItemsController, type: :request do
+    describe 'GET /v1/menu_items' do
+        before do
+            get 'api/v1/menu_items'
+        end
+
+        it 'should return a 200 response' do
+            expect(response).to have_http_status 200
+        end
+
+        describe 'should return a response with' do
+            before do
+                json_response = JSON.parse(response.body)
+            end
+
+            it 'should return a list of menu items' do
+                expect(json_response.length).to eq 3
+            end
+
+            it 'should return items with a name' do
+                expect(json_response[0][:name]).to eq 'Pickled egg'
+            end
+        end
+    end
+end

--- a/spec/requests/api/v1/menu_items_spec.rb
+++ b/spec/requests/api/v1/menu_items_spec.rb
@@ -1,10 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::MenuItemsController, type: :request do
-    let!(:food1) { create(:menu_item, name: 'Pickled Egg', description: 'An egg that is in a reeeeal pickle!', price: 69) }
-    let!(:food2) { create(:menu_item, name: 'Bread', description: 'Simply bread', price: 25) }
-    let!(:food3) { create(:menu_item, name: 'Ham Sandwich', description: 'No, not hamBURGER, ham SANDWICH', price: 42) }
-
+  let!(:menu_items) { 3.times { create(:menu_item) } }
     describe 'GET /v1/menu_items' do
         before do
             get '/api/v1/menu_items'
@@ -14,20 +11,16 @@ RSpec.describe Api::V1::MenuItemsController, type: :request do
             expect(response).to have_http_status 200
         end
 
-        describe 'should return a response with' do
-            let(:json_response) { JSON.parse(response.body) }
+        it 'should return a list of menu items' do
+            expect(response_json["menu_items"].length).to eq 3
+        end
 
-            it 'should return a list of menu items' do
-                expect(json_response["items"].length).to eq 3
-            end
+        it 'should return items with a name' do
+            expect(response_json["menu_items"][0]).to have_key('name')
+        end
 
-            it 'should return items with a name' do
-                expect(json_response["items"][0]["name"]).to eq food1.name
-            end
-
-            it 'should return items with a price' do
-                expect(json_response["items"][0]["price"]).to eq food1.price
-            end
+        it 'should return items with a price' do
+            expect(response_json["menu_items"][0]).to have_key('price')
         end
     end
 end

--- a/spec/support/response_json.rb
+++ b/spec/support/response_json.rb
@@ -1,0 +1,5 @@
+module ResponseJSON
+  def response_json
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
### Show menu items
This PR adds the ability for the API to serve menu items from the database.
It also adds the menu_item model, and tests for the model.
The endpoint is GET '/api/v1/menu_items'
It takes no params and returns
`{ items: [<MenuItem>,<MenuItem>]}` where each `MenuItem` has id, name, description and price.
[PT Card](https://www.pivotaltracker.com/story/show/172642043)