### PR TITLE
API can provide products sorted in categories

### DIFF
--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::MenuItemsController < ApplicationController
   def index
-    if (params[:category].nil? || params[:category] == "") then
-      items = MenuItem.all
-    else
+    if params[:category]
       items = MenuItem.where category: params[:category]
+    else
+      items = MenuItem.all
     end
     render json: { menu_items: items }
   end

--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::MenuItemsController < ApplicationController
   def index
-    items = MenuItem.all
+    if (params[:category].nil? || params[:category] == "") then
+      items = MenuItem.all
+    else
+      items = MenuItem.where category: params[:category]
+    end
     render json: { menu_items: items }
   end
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,3 +1,4 @@
 class MenuItem < ApplicationRecord
+  enum category: [:starter, :main_course, :dessert, :drinks, :extras]
 	validates_presence_of :name, :price, :category
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,3 +1,3 @@
 class MenuItem < ApplicationRecord
-	validates_presence_of :name, :price
+	validates_presence_of :name, :price, :category
 end

--- a/db/migrate/20200506161640_add_category_to_menu_items.rb
+++ b/db/migrate/20200506161640_add_category_to_menu_items.rb
@@ -1,0 +1,5 @@
+class AddCategoryToMenuItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :menu_items, :category, :string
+  end
+end

--- a/db/migrate/20200506161640_add_category_to_menu_items.rb
+++ b/db/migrate/20200506161640_add_category_to_menu_items.rb
@@ -1,5 +1,5 @@
 class AddCategoryToMenuItems < ActiveRecord::Migration[6.0]
   def change
-    add_column :menu_items, :category, :string
+    add_column :menu_items, :category, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_094341) do
+ActiveRecord::Schema.define(version: 2020_05_06_161640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_094341) do
     t.float "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "category"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_161640) do
     t.float "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "category"
+    t.integer "category"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/menu_items.rb
+++ b/spec/factories/menu_items.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     name { "MyString" }
     description { "MyText" }
     price { 69.0 }
-    category { "Extras" }
+    category { "starter" }
   end
 end

--- a/spec/factories/menu_items.rb
+++ b/spec/factories/menu_items.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { "MyString" }
     description { "MyText" }
     price { 69.0 }
+    category { "Extras" }
   end
 end

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe MenuItem, type: :model do
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :description }
     it { is_expected.to have_db_column :price }
+    it { is_expected.to have_db_column :category}
   end
 
   describe 'Validation' do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :price }
+    it { is_expected.to validate_presence_of :category }
   end
 
   describe 'Factory' do

--- a/spec/requests/api/v1/menu_items_by_category_spec.rb
+++ b/spec/requests/api/v1/menu_items_by_category_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::MenuItemsController, type: :request do
+  let!(:menu_items) { 3.times { create(:menu_item) } }
+  let!(:menu_items2) { 3.times { create(:menu_item, category: "Dessert") } }
+
+  describe 'gets items from a single category' do
+    before do
+      get '/api/v1/menu_items', params: { category: "Dessert"}
+    end
+
+    it 'gets only the Dessert items' do
+      expect(response_json["menu_items"].length).to eq 3
+    end
+
+    it 'all items have the desired category' do
+      response_json["menu_items"].each { |menu_item|
+        expect(menu_item["category"]).to eq "Dessert"
+      }
+    end
+  end
+end

--- a/spec/requests/api/v1/menu_items_by_category_spec.rb
+++ b/spec/requests/api/v1/menu_items_by_category_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::MenuItemsController, type: :request do
   let!(:menu_items) { 3.times { create(:menu_item) } }
-  let!(:menu_items2) { 3.times { create(:menu_item, category: "Dessert") } }
+  let!(:menu_items2) { 3.times { create(:menu_item, category: 2) } }
 
   describe 'gets items from a single category' do
     before do
-      get '/api/v1/menu_items', params: { category: "Dessert"}
+      get '/api/v1/menu_items', params: { category: 2}
     end
 
     it 'gets only the Dessert items' do
@@ -15,7 +15,7 @@ RSpec.describe Api::V1::MenuItemsController, type: :request do
 
     it 'all items have the desired category' do
       response_json["menu_items"].each { |menu_item|
-        expect(menu_item["category"]).to eq "Dessert"
+        expect(menu_item["category"]).to eq "dessert"
       }
     end
   end

--- a/spec/requests/api/v1/menu_items_spec.rb
+++ b/spec/requests/api/v1/menu_items_spec.rb
@@ -1,26 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::MenuItemsController, type: :request do
-  let!(:menu_items) { 3.times { create(:menu_item) } }
+    let!(:menu_items) { 3.times { create(:menu_item) } }
+
     describe 'GET /v1/menu_items' do
         before do
-            get '/api/v1/menu_items'
+          get '/api/v1/menu_items'
         end
 
         it 'should return a 200 response' do
-            expect(response).to have_http_status 200
+          expect(response).to have_http_status 200
         end
 
         it 'should return a list of menu items' do
-            expect(response_json["menu_items"].length).to eq 3
+          expect(response_json["menu_items"].length).to eq 3
         end
 
         it 'should return items with a name' do
-            expect(response_json["menu_items"][0]).to have_key('name')
+          expect(response_json["menu_items"][0]).to have_key('name')
         end
 
         it 'should return items with a price' do
-            expect(response_json["menu_items"][0]).to have_key('price')
+          expect(response_json["menu_items"][0]).to have_key('price')
+        end
+
+        it 'should return items with a category' do
+          expect(response_json["menu_items"][0]).to have_key('category')
         end
     end
 end


### PR DESCRIPTION
## API can provide products sorted in categories
[PT Card](https://www.pivotaltracker.com/story/show/172642042)
### In this PR:
Adding category to menu_items model and db table.
This is validated to be present, as any item without a clear category can be added as “Other”.
You can filter the return of the response from '/menu_item' by providing the param "category", which will return only the items from the db matching the specified category.