### PR TITLE
API provides functionality for user to create order

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::OrdersController < ApplicationController
   def create
-    order = Order.create
+    order = Order.create(user_id: params[:user])
     order.order_items.create(menu_item_id: params[:menu_item])
     render json: { id: order.id, message: "Item added to order" }
   end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::OrdersController < ApplicationController
   def create
     order = Order.create
-    order.order_items.create(params["menu_item".id])
-    render json: { id: order.id }
+    order.order_items.create(menu_item_id: params[:menu_item])
+    render json: { id: order.id, message: "Item added to order" }
   end
 end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OrdersController < ApplicationController
+  def create
+    order = Order.create
+    order.order_items.create(params["menu_item".id])
+    render json: { id: order.id }
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,3 @@
+class Order < ApplicationRecord
+  has_many :order_items
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,4 @@
 class Order < ApplicationRecord
+  belongs_to :user, optional: true
   has_many :order_items
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,0 +1,4 @@
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :menu_item
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     end
     namespace :v1 do
       resources :menu_items, only: [:index], constraints: { format: 'json' }
-      resources :orders, only: [:create, :update], constraints: { format: 'json' }
+      resources :orders, only: [:create], constraints: { format: 'json' }
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     end
     namespace :v1 do
       resources :menu_items, only: [:index], constraints: { format: 'json' }
+      resources :orders, only: [:create, :update], constraints: { format: 'json' }
     end
   end
 end

--- a/db/migrate/20200507095320_create_orders.rb
+++ b/db/migrate/20200507095320_create_orders.rb
@@ -1,0 +1,8 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200507095320_create_orders.rb
+++ b/db/migrate/20200507095320_create_orders.rb
@@ -1,7 +1,7 @@
 class CreateOrders < ActiveRecord::Migration[6.0]
   def change
     create_table :orders do |t|
-
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200507095934_create_order_items.rb
+++ b/db/migrate/20200507095934_create_order_items.rb
@@ -1,0 +1,10 @@
+class CreateOrderItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :order_items do |t|
+      t.references :order, null: false, foreign_key: true
+      t.references :menu_item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,8 +34,10 @@ ActiveRecord::Schema.define(version: 2020_05_07_095934) do
   end
 
   create_table "orders", force: :cascade do |t|
+    t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -67,4 +69,5 @@ ActiveRecord::Schema.define(version: 2020_05_07_095934) do
 
   add_foreign_key "order_items", "menu_items"
   add_foreign_key "order_items", "orders"
+  add_foreign_key "orders", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_161640) do
+ActiveRecord::Schema.define(version: 2020_05_07_095934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,20 @@ ActiveRecord::Schema.define(version: 2020_05_06_161640) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "category"
+  end
+
+  create_table "order_items", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "menu_item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["menu_item_id"], name: "index_order_items_on_menu_item_id"
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -51,4 +65,6 @@ ActiveRecord::Schema.define(version: 2020_05_06_161640) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "order_items", "menu_items"
+  add_foreign_key "order_items", "orders"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,6 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-food1 = MenuItem.create(name: 'Pickled Egg', description: 'An egg that is a reeeeal pickle!', price: 69)
-food2 = MenuItem.create(name: 'Bread', description: 'Simply bread', price: 25)
-food3 = MenuItem.create(name: 'Ham Sandwich', description: 'No, not hamBURGER, ham SANDWICH', price: 42)
+food1 = MenuItem.create(name: 'Pickled Egg', description: 'An egg that is in a reeeeal pickle!', price: 69, category: 0)
+food2 = MenuItem.create(name: 'Bread', description: 'Simply bread', price: 25, category: 0)
+food3 = MenuItem.create(name: 'Ham Sandwich', description: 'No, not hamBURGER, ham SANDWICH', price: 42, category: 1)

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order_item do
+    order { nil }
+    user { nil }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe OrderItem, type: :model do
+  describe 'Relations' do
+    it { is_expected.to belong_to :order }
+    it { is_expected.to belong_to :menu_item }
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Order, type: :model do
   describe 'relations' do
-    it { is_expected.to have_many :order_items}
+    it { is_expected.to have_many :order_items }
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  describe 'relations' do
+    it { is_expected.to have_many :order_items}
+  end
+end

--- a/spec/requests/api/v1/can_add_items_to_order_spec.rb
+++ b/spec/requests/api/v1/can_add_items_to_order_spec.rb
@@ -14,29 +14,15 @@ RSpec.describe Api::V1::OrdersController, type: :request do
     end
 
     it 'has a success message' do
-      expect(response.message).to eq "Item added to order"
+      expect(response_json["message"]).to eq "Item added to order"
     end
 
     it 'returns the opened order id' do
-      expect(response).to have_key('id')
-    end
-  end
-
-  describe 'PUT /api/v1/order/:id, =further items' do
-    before do
-      
+      expect(response_json).to have_key('id')
     end
 
-    it 'responds with a 200 status' do
-      skip("TODO")
+    it 'has the first item in it' do
+      expect(Order.last.order_items[0]["menu_item_id"]).to eq food1.id
     end
-
-    it 'responds with a success message' do
-      skip("TODO")
-    end
-  end
-
-  describe 'GET /api/v1/order/:id, fetch the order in its current status' do
-
   end
 end

--- a/spec/requests/api/v1/can_add_items_to_order_spec.rb
+++ b/spec/requests/api/v1/can_add_items_to_order_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::OrdersController, type: :request do
+  let(:food1) { create(:menu_item)}
+  let(:food2) { create(:menu_item, name: "Corn")}
+
+  describe 'POST /api/v1/order, =first item' do
+    before do
+      post '/api/v1/orders', params: { menu_item: food1.id }
+    end
+
+    it 'responds with a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'has a success message' do
+      expect(response.message).to eq "Item added to order"
+    end
+
+    it 'returns the opened order id' do
+      expect(response).to have_key('id')
+    end
+  end
+
+  describe 'PUT /api/v1/order/:id, =further items' do
+    before do
+      
+    end
+
+    it 'responds with a 200 status' do
+      skip("TODO")
+    end
+
+    it 'responds with a success message' do
+      skip("TODO")
+    end
+  end
+
+  describe 'GET /api/v1/order/:id, fetch the order in its current status' do
+
+  end
+end

--- a/spec/requests/api/v1/can_add_items_to_order_spec.rb
+++ b/spec/requests/api/v1/can_add_items_to_order_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe Api::V1::OrdersController, type: :request do
   let(:food1) { create(:menu_item)}
   let(:food2) { create(:menu_item, name: "Corn")}
+  let(:user) { create(:user)}
 
-  describe 'POST /api/v1/order, =first item' do
+  describe 'POST /api/v1/order, without user' do
     before do
       post '/api/v1/orders', params: { menu_item: food1.id }
     end
@@ -23,6 +24,16 @@ RSpec.describe Api::V1::OrdersController, type: :request do
 
     it 'has the first item in it' do
       expect(Order.last.order_items[0]["menu_item_id"]).to eq food1.id
+    end
+  end
+
+  describe 'POST /api/v1/order, with user' do
+    before do
+      post '/api/v1/orders', params: { menu_item: food1.id, user: user.id }
+    end
+
+    it ' belongs to user' do
+      expect(Order.last["user_id"]).to eq user.id
     end
   end
 end


### PR DESCRIPTION
[PT card](https://www.pivotaltracker.com/story/show/172642040)
## In this PR
- Adding functionality to start an order through the api
- Tests for said functionality
- Order model and order_item model

Anyone can start an order by `POST /api/v1/orders, params { menu_item:  :id}`.
This will return the ID of the created order and a success message.
A user does not need to be authenticated to create the order. I have created a new [PT card](https://www.pivotaltracker.com/story/show/172722001) that will address this to make sure user is added before order is confirmed.