### PR TITLE
API provides functionality to add a user to order after its creation

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -9,11 +9,17 @@ class Api::V1::OrdersController < ApplicationController
 
   def update
     order = Order.find(params[:id])
-    if params[:activity] && !order.user.nil?
-      order.update_attribute(:finalized, true)
-      render json: { message: 'Your order will be ready in 30 minutes!' }
-    elsif params[:activity] && order.user.nil?
-      render json: { message: 'You need to be logged in' }
+    case params[:activity]
+    when "finalize"
+      if !order.user.nil?
+        order.update_attribute(:finalized, true)
+        render json: { message: 'Your order will be ready in 30 minutes!' }
+      else 
+        render json: { message: 'You need to be logged in' }
+      end
+    when "login"
+      order.update_attribute(:user_id, params[:user])
+      render json: { message: 'User added to order' }
     else
       menu_item = MenuItem.find(params[:menu_item])
       order.order_items.create(menu_item: menu_item)

--- a/spec/requests/api/v1/can_add_user_to_order.rb
+++ b/spec/requests/api/v1/can_add_user_to_order.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::OrdersController, type: :request do
+  let(:food1) { create(:menu_item) }
+  let(:food2) { create(:menu_item, name: 'Corn') }
+  let(:user) { create(:user) }
+
+  describe 'PUT /api/v1/order, adding user' do
+    before do
+      post '/api/v1/orders', params: { menu_item: food1.id }
+      @order_id = response_json['order']['id']
+      put "/api/v1/orders/#{@order_id}", params: { activity: "login", user: user.id }
+    end
+    
+    it 'responds with 200 ok' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'gives back a success message' do
+      expect(response_json["message"]).to eq "User added to order"
+    end
+
+    it 'now has the user on the order' do
+      expect(Order.last.user_id).to eq user.id
+    end
+  end
+end


### PR DESCRIPTION
## Can add user to order post creation

It is now possible to add a user to the order after it has been created, and should be called on the moment the user logs in to the browser and has an order started.
It is available at `PUT /order/:id, params: { activity: "login", user: user.id }.`

[PT](https://www.pivotaltracker.com/story/show/172722001)
