### PR TITLE
Fix for create action

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -2,22 +2,23 @@
 
 class Api::V1::OrdersController < ApplicationController
   def create
-    order = Order.create(user_id: params[:user])
+    user = User.find_by(email: params[:user])
+    order = Order.create(user: user)
     order.order_items.create(menu_item_id: params[:menu_item])
     render json: create_json_response(order)
   end
 
   def update
-    order = Order.find(params[:id])
+    order = Order.find(params[:id]) # Update action needs to get email params from frontend just like create action
     case params[:activity]
-    when "finalize"
+    when 'finalize'
       if !order.user.nil?
         order.update_attribute(:finalized, true)
         render json: { message: 'Your order will be ready in 30 minutes!' }
-      else 
+      else
         render json: { message: 'You need to be logged in' }
       end
-    when "login"
+    when 'login'
       order.update_attribute(:user_id, params[:user])
       render json: { message: 'User added to order' }
     else

--- a/spec/requests/api/v1/can_add_items_to_order_spec.rb
+++ b/spec/requests/api/v1/can_add_items_to_order_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::OrdersController, type: :request do
 
   describe 'POST /api/v1/order, with user' do
     before do
-      post '/api/v1/orders', params: { menu_item: food1.id, user: user.id }
+      post '/api/v1/orders', params: { menu_item: food1.id, user: user.email }
     end
 
     it ' belongs to user' do


### PR DESCRIPTION
Email params received from front end is used in create action to find corresponding user
So now, logged in customers can create orders with their id's, finalize will not fail for them
Logged out users can't finalize